### PR TITLE
Change default position of new part

### DIFF
--- a/tools/NewPart.lua
+++ b/tools/NewPart.lua
@@ -126,7 +126,7 @@ Tools.NewPart.Listeners.Button1Down = function ()
 	-- that the user could easily position their new part
 	equipTool( Tools.Move );
 	Tools.Move.ManualTarget = NewPart;
-	NewPart.CFrame = CFrame.new( Mouse.Hit.p );
+	NewPart.CFrame = CFrame.new( Mouse.Hit.p + Vector3.new(0, NewPart.Size.y, 0) );
 	Tools.Move.Listeners.Button1Down();
 	Tools.Move.Listeners.Move();
 


### PR DESCRIPTION
The default position of a newly created part should be with the bottom of the part where the mouse was clicked, not in the middle.
