### PR TITLE
Support 't' selection box hide/show.

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -2390,7 +2390,7 @@ function equipBT( CurrentMouse )
 		equipTool( Tools.Move );
 	end;
 
-	if not TargetBox and showselectlines==true then
+	if not TargetBox then
 		TargetBox = Instance.new( "SelectionBox", UI );
 		TargetBox.Name = "BTTargetBox";
 		TargetBox.Color = BrickColor.new( "Institutional white" );

--- a/Core.lua
+++ b/Core.lua
@@ -45,6 +45,7 @@ ToolAssetID = 142785488;
 Tool = script.Parent;
 Player = Services.Players.LocalPlayer;
 Mouse = nil;
+local showselectlines=true;
 
 -- Set tool or plugin-specific references
 if plugin then
@@ -846,9 +847,16 @@ Dragger = nil;
 
 function updateSelectionBoxColor()
 	-- Updates the color of the selectionboxes
-	for _, SelectionBox in pairs( SelectionBoxes ) do
-		SelectionBox.Color = SelectionBoxColor;
-	end;
+	if showselectlines==true then
+		for _, SelectionBox in pairs( SelectionBoxes ) do
+			SelectionBox.Color = SelectionBoxColor;
+			SelectionBox.Visible=true;
+		end;
+	else
+		for _, SelectionBox in pairs( SelectionBoxes ) do
+			SelectionBox.Visible=false;
+		end;
+	end 
 end;
 
 Selection = {
@@ -2382,7 +2390,7 @@ function equipBT( CurrentMouse )
 		equipTool( Tools.Move );
 	end;
 
-	if not TargetBox then
+	if not TargetBox and showselectlines==true then
 		TargetBox = Instance.new( "SelectionBox", UI );
 		TargetBox.Name = "BTTargetBox";
 		TargetBox.Color = BrickColor.new( "Institutional white" );
@@ -2504,7 +2512,11 @@ function equipBT( CurrentMouse )
 
 		elseif key == "p" then
 			equipTool( Tools.Decorate );
-
+			
+		elseif key == "t" then
+			showselectlines = not showselectlines;
+			updateSelectionBoxColor()
+			
 		end;
 
 		ActiveKeys[key_code] = key_code;


### PR DESCRIPTION
To allow the 't' keybind button to hide and show selection boxes, to make it easier to make precision adjustments

A lot of my friends that like using the F3x tool, find that with the selection box, that making small adjustments are tricky with the selection boxes showing.
I modified the F3X code to help support a 't' key to toggle the visibility of the selection box to help out.
Here's an example place, http://www.roblox.com/games/282968777/nBD-Testing
Go ingame, say :f3x me, and select a few things, and press t.
(In-Game nBD permissions will allow you to say :f3x me, and :resize me .5)