### PR TITLE
Fix Signal:Connect from erroring if arguments nil

### DIFF
--- a/Libraries/Signal.lua
+++ b/Libraries/Signal.lua
@@ -43,7 +43,9 @@ function Signal:Connect(handler)
 	end
 
 	return self._bindableEvent.Event:Connect(function()
-		handler(unpack(self._argData, 1, self._argCount))
+		if self._argData ~= nil and self._argCount ~= nil then
+			handler(unpack(self._argData, 1, self._argCount))
+		end
 	end)
 end
 


### PR DESCRIPTION
An error is generated when a selection is removed instantly directly after it is created (most prevalent when done through code.) This spams the output console, and is generally undesirable behavior.