### PR TITLE
Made SpawnLocation and Seats appearence same as in studio.

### DIFF
--- a/SyncAPI.lua
+++ b/SyncAPI.lua
@@ -1855,9 +1855,10 @@ function CreatePart(PartType)
 	elseif PartType == 'Spawn' then
 		NewPart = Instance.new('SpawnLocation')
 		NewPart.Size = Vector3.new(6, 1, 6)
-		local SpawnDecal = Instance.new('Decal', NewPart)
+		local SpawnDecal = Instance.new('Decal')
 		SpawnDecal.Face = Enum.NormalId.Top
 		SpawnDecal.Texture = 'rbxasset://textures/SpawnLocation.png'
+		SpawnDecal.Parent = NewPart
 	end
 
 	-- Make part surfaces smooth

--- a/SyncAPI.lua
+++ b/SyncAPI.lua
@@ -1845,14 +1845,19 @@ function CreatePart(PartType)
 	elseif PartType == 'Seat' then
 		NewPart = Instance.new('Seat')
 		NewPart.Size = Vector3.new(4, 1, 2)
+		NewPart.BrickColor = BrickColor.Black()
 
 	elseif PartType == 'Vehicle Seat' then
 		NewPart = Instance.new('VehicleSeat')
 		NewPart.Size = Vector3.new(4, 1, 2)
+		NewPart.BrickColor = BrickColor.Black()
 
 	elseif PartType == 'Spawn' then
 		NewPart = Instance.new('SpawnLocation')
-		NewPart.Size = Vector3.new(4, 1, 2)
+		NewPart.Size = Vector3.new(4, 1, 4)
+		local SpawnDecal = Instance.new('Decal', NewPart)
+		SpawnDecal.Face = Enum.NormalId.Top
+		SpawnDecal.Texture = 'rbxasset://textures/SpawnLocation.png'
 	end
 
 	-- Make part surfaces smooth

--- a/SyncAPI.lua
+++ b/SyncAPI.lua
@@ -1854,7 +1854,7 @@ function CreatePart(PartType)
 
 	elseif PartType == 'Spawn' then
 		NewPart = Instance.new('SpawnLocation')
-		NewPart.Size = Vector3.new(4, 1, 4)
+		NewPart.Size = Vector3.new(6, 1, 6)
 		local SpawnDecal = Instance.new('Decal', NewPart)
 		SpawnDecal.Face = Enum.NormalId.Top
 		SpawnDecal.Texture = 'rbxasset://textures/SpawnLocation.png'


### PR DESCRIPTION
So normally in studio when you create a spawnlocation it has a square shape and has a the spawn decal on top of it.
Also Seats and VehicleSeats have their brickcolor set to black when created in studio.

Also for me at least in F3X BTools when spawning these parts you easily confuse them with regular parts.