### PR TITLE
Add property copying shortcut to material tool.

### DIFF
--- a/Core/init.lua
+++ b/Core/init.lua
@@ -969,6 +969,11 @@ function GetPartJoints(Part, Whitelist)
 
 	local Joints = {};
 
+	-- Get joints stored inside `Part`
+	for Joint, JointParent in pairs(SearchJoints(Part, Part, Whitelist)) do
+		Joints[Joint] = JointParent;
+	end;
+
 	-- Get joints stored inside connected parts
 	for _, ConnectedPart in pairs(GetConnectedParts(Part)) do
 		for Joint, JointParent in pairs(SearchJoints(ConnectedPart, Part, Whitelist)) do

--- a/Core/init.lua
+++ b/Core/init.lua
@@ -969,11 +969,6 @@ function GetPartJoints(Part, Whitelist)
 
 	local Joints = {};
 
-	-- Get joints stored inside `Part`
-	for Joint, JointParent in pairs(SearchJoints(Part, Part, Whitelist)) do
-		Joints[Joint] = JointParent;
-	end;
-
 	-- Get joints stored inside connected parts
 	for _, ConnectedPart in pairs(GetConnectedParts(Part)) do
 		for Joint, JointParent in pairs(SearchJoints(ConnectedPart, Part, Whitelist)) do

--- a/Tools/Material.lua
+++ b/Tools/Material.lua
@@ -85,6 +85,19 @@ local Materials = {
 	[Enum.Material.Wood] = 'Wood';
 	[Enum.Material.WoodPlanks] = 'Wood Planks';
 	[Enum.Material.Glass] = 'Glass';
+	[Enum.Material.Asphalt] = 'Asphalt';
+	[Enum.Material.Basalt] = 'Basalt';
+	[Enum.Material.CrackedLava] = 'Cracked Lava';
+	[Enum.Material.Glacier] = 'Glacier';
+	[Enum.Material.Ground] = 'Ground';
+	[Enum.Material.LeafyGrass] = 'Leafy Grass';
+	[Enum.Material.Limestone] = 'Limestone';
+	[Enum.Material.Mud] = 'Mud';
+	[Enum.Material.Pavement] = 'Pavement';
+	[Enum.Material.Rock] = 'Rock';
+	[Enum.Material.Salt] = 'Salt';
+	[Enum.Material.Sandstone] = 'Sandstone';
+	[Enum.Material.Snow] = 'Snow';
 };
 
 function MaterialTool:ShowUI()

--- a/Tools/Material.lua
+++ b/Tools/Material.lua
@@ -29,7 +29,10 @@ local MaterialTool = {
 }
 
 MaterialTool.ManualText = [[<font face="GothamBlack" size="16">Material Tool  🛠</font>
-Lets you change the material, transparency, and reflectance of parts.]]
+Lets you change the material, transparency, and reflectance of parts.
+
+<b>TIP:</b> Press <b><i>R</i></b> while hovering over a part to copy its material properties.]]
+
 
 -- Container for temporary connections (disconnected automatically)
 local Connections = {};
@@ -39,6 +42,7 @@ function MaterialTool:Equip()
 
 	-- Start up our interface
 	self:ShowUI()
+	BindShortcutKeys()
 
 end;
 
@@ -177,6 +181,42 @@ function SyncInputToProperty(Property, Input)
 	Input.FocusLost:Connect(function ()
 		SetProperty(Property, tonumber(Input.Text));
 	end);
+
+end;
+
+function BindShortcutKeys()
+	-- Enables useful shortcut keys for this tool
+
+	-- Track user input while this tool is equipped
+	table.insert(Connections, UserInputService.InputBegan:Connect(function (InputInfo, GameProcessedEvent)
+		-- Make sure this is an intentional event
+		if GameProcessedEvent then
+			return;
+		end;
+
+		-- Make sure this input is a key press
+		if InputInfo.UserInputType ~= Enum.UserInputType.Keyboard then
+			return;
+		end;
+
+		-- Make sure it wasn't pressed while typing
+		if UserInputService:GetFocusedTextBox() then
+			return;
+		end;
+
+		-- Check if the enter key was pressed
+		if InputInfo.KeyCode == Enum.KeyCode.R then
+
+			-- Set selection's properties to that of the target (if any)
+			if Core.Mouse.Target then
+				SetProperty('Material', Core.Mouse.Target.Material)
+				SetProperty('Transparency', Core.Mouse.Target.Transparency)
+				SetProperty('Reflectance', Core.Mouse.Target.Reflectance)
+			end;
+
+		end;
+
+	end));
 
 end;
 


### PR DESCRIPTION
This shortcut allows you to press R to copy the material, transparency, and reflectance of a part you are mousing over, similar to the paint tool's color copying.