### PR TITLE
Update F3X to use PivotTo where possible

### DIFF
--- a/Tools/Move/HandleDragging.lua
+++ b/Tools/Move/HandleDragging.lua
@@ -83,13 +83,13 @@ function HandleDragging:AttachHandles(Part, Autofocus)
 		end
 
 		-- Stop parts from moving, and capture the initial state of the parts
-		local InitialPartStates, InitialModelStates, InitialFocusCFrame = self.Tool:PrepareSelectionForDragging()
+		local InitialPartStates, InitialRootStates, InitialFocusCFrame = self.Tool:PrepareSelectionForDragging()
 		self.InitialPartStates = InitialPartStates
-		self.InitialModelStates = InitialModelStates
+		self.InitialRootStates = InitialRootStates
 		self.InitialFocusCFrame = InitialFocusCFrame
 
 		-- Track the change
-		self.Tool:TrackChange()
+		self.Tool:TrackChange(InitialRootStates)
 
 		-- Cache area permissions information
 		if Core.Mode == 'Tool' then
@@ -110,13 +110,13 @@ function HandleDragging:AttachHandles(Part, Autofocus)
 		Distance = MoveUtil.GetIncrementMultiple(Distance, self.Tool.Increment)
 
 		-- Move the parts along the selected axes by the calculated distance
-		self.Tool:MovePartsAlongAxesByFace(Face, Distance, self.InitialPartStates, self.InitialModelStates, self.InitialFocusCFrame)
+		self.Tool:MovePartsAlongAxesByFace(Face, Distance, self.InitialPartStates, self.InitialRootStates, self.InitialFocusCFrame)
 
 		-- Make sure we're not entering any unauthorized private areas
 		if Core.Mode == 'Tool' and Security.ArePartsViolatingAreas(Selection.Parts, Core.Player, false, AreaPermissions) then
-			local Part, InitialPartState = next(self.InitialPartStates)
-			Part.CFrame = InitialPartState.CFrame
-			MoveUtil.TranslatePartsRelativeToPart(Part, self.InitialPartStates, self.InitialModelStates)
+			for Root, InitialPivot in self.InitialRootStates do
+				Root:PivotTo(InitialPivot)
+			end
 			Distance = 0
 		end
 


### PR DESCRIPTION
* Previously, F3X always individually moved all of the parts in the selection even if they were under models. This is not optimal, if all the parts are under a single model then it suffices to make a single PivotTo call transforming the model.

* Change SyncRotate/SyncMove into SyncRootTransform/SyncPartTransform which are both used by Rotate and Move. In the case where the "Local" mode is used, each part is moved indiviudally, and synced via SyncPartTransform. In the case where "Center" or "Last" is used, the set of rootmost PVInstances is moved via PivotTo and synced via SyncRootTransform.

* The code specific to updating pivots has been removed, as PivotTo automatically updates WorldPivots when moving the hierarchy.

* One minor behavior change here is that when using "Local" mode with the Rotate tool, the rotation of the model's pivot is no longer updated. Maintaining that behavior under this new syncing scheme added unnecessary complexity and it was probably a mistake to include that behavior in the first place when updating F3X to respect pivots.