### PR TITLE
Fix critical F3X vulnerability 

### DIFF
--- a/SyncAPI.lua
+++ b/SyncAPI.lua
@@ -732,7 +732,7 @@ Actions = {
 
 			-- Apply each surface change
 			for Surface, SurfaceType in pairs(Change.Surfaces) do
-				Part[Surface .. 'Surface'] = SurfaceType;
+				Part[tostring(Surface .. "Surface")] = SurfaceType;
 			end;
 
 		end;

--- a/SyncAPI.lua
+++ b/SyncAPI.lua
@@ -732,7 +732,7 @@ Actions = {
 
 			-- Apply each surface change
 			for Surface, SurfaceType in pairs(Change.Surfaces) do
-				Part[tostring(Surface .. "Surface")] = SurfaceType;
+				Part[tostring(Surface) .. "Surface"] = SurfaceType;
 			end;
 
 		end;


### PR DESCRIPTION
This vulnerability allowed people to edit any property in part, without limitations. This vulnerability was leaked, therefore it should be immediately fixed. This worked by utilizing "\0" to eliminate concation of "Surface", tostring should fix this.