### PR TITLE
Fixed CreatePart and Clone failing to work under Content Streaming

### DIFF
--- a/SyncAPI.lua
+++ b/SyncAPI.lua
@@ -1,3 +1,4 @@
+local CollectionService = game:GetService("CollectionService")
 local HttpService = game:GetService('HttpService')
 local RunService = game:GetService('RunService')
 
@@ -57,19 +58,21 @@ Actions = {
 		end
 
 		local Clones = {}
+		local CloneTag = string.format("F3X:%s", HttpService:GenerateGUID())
 
 		-- Clone items
 		for _, Item in pairs(Items) do
 			local Clone = Item:Clone()
 			Clone.Parent = Parent
-
+			CollectionService:AddTag(Clone, CloneTag)
+		
 			-- Register the clone
 			table.insert(Clones, Clone)
 			CreatedInstances[Item] = Item
 		end
-
-		-- Return the clones
-		return Clones
+		
+		-- Return tag the clones will have
+		return CloneTag
 	end;
 
 	['CreatePart'] = function (PartType, Position, Parent)
@@ -99,8 +102,12 @@ Actions = {
 		-- Register the part
 		CreatedInstances[NewPart] = NewPart;
 
+		-- Create the tag to watch for.
+		local NewPartTag = string.format("F3X:%s", HttpService:GenerateGUID())
+		CollectionService:AddTag(NewPart, NewPartTag)
+
 		-- Return the part
-		return NewPart;
+		return NewPartTag;
 	end;
 
 	['CreateGroup'] = function (Type, Parent, Items)


### PR DESCRIPTION
By using tags, we can wait for the parts to replicate in. Right now, F3X falters at creating/cloning parts with content streaming. This is because the code assumes that the instances will instantly replicate, which is no longer true with content streaming. Hence, the list of parts the client receives from the server becomes empty, despite being created on the server.

So, from the server, we give the client a tag to listen to for the newly made parts. Most times, it shouldn't need to wait for the parts to come. But, with enough parts being cloned, it may need to wait for several chunks. However, sometimes the parts will never stream in if far enough, so simply best to give up after a reasonable amount of time.