### PR TITLE
Asset ID extraction upgrades & Misc HTTP upgrades

### DIFF
--- a/SyncAPI.lua
+++ b/SyncAPI.lua
@@ -1,5 +1,7 @@
 local HttpService = game:GetService('HttpService')
 local RunService = game:GetService('RunService')
+local InsertService = game:GetService("InsertService")
+local MarketplaceService = game:GetService("MarketplaceService")
 
 -- References
 SyncAPI = script.Parent;
@@ -24,7 +26,7 @@ Options = {
 CreatedInstances = {};
 LastParents = {};
 
--- Provide cached data for 
+-- Provide cached data for requests
 local assetTypeCache = {}
 local imageIdCache = {}
 local IsHttpServiceEnabled = nil
@@ -32,6 +34,7 @@ local IsHttpServiceEnabled = nil
 -- Determine whether we're in tool or plugin mode
 ToolMode = (Tool.Parent:IsA 'Plugin') and 'Plugin' or 'Tool'
 
+-- Get asset type from asset id
 local function getAssetType(assetId)
 	if assetTypeCache[assetId] then
 		return assetTypeCache[assetId]
@@ -47,7 +50,8 @@ local function getAssetType(assetId)
 	end
 end
 
-local function getImageFromDecal(assetId) then
+-- Extract imageid from decalid via insertservice
+local function getImageFromDecal(assetId)
 	if imageIdCache[assetId] then
 		return imageIdCache[assetId]
 	end

--- a/SyncAPI.lua
+++ b/SyncAPI.lua
@@ -1626,7 +1626,7 @@ Actions = {
 		-- Push serialized data to server
 		local Response = HttpService:JSONDecode(
 			HttpService:PostAsync(
-				'http://f3xteam.com/bt/export',
+				'https://f3xteam.com/bt/export',
 				HttpService:JSONEncode { data = SerializedBuildData, version = 3, userId = (Player and Player.UserId) },
 				Enum.HttpContentType.ApplicationJson,
 				true


### PR DESCRIPTION
- Made imageid extraction and meshid extraction use automatic checking for imageassets, and make it client-sided for better UX
- Made imageid extraction & mesh id extraction use InsertService when possible to make working with games with no HTTP service easier
- Made meshid extraction work with decals to apply image id to meshesh
- Made HTTP checking better & much faster
- Upgraded to secure HTTP