### PR TITLE
Fixed resize-snap bug

### DIFF
--- a/Tools/Resize.lua
+++ b/Tools/Resize.lua
@@ -836,6 +836,10 @@ function StartSnapping()
 
 	-- Listen for when the user starts dragging while in snap mode
 	Connections.SnapDragStart = Support.AddUserInputListener('Began', 'MouseButton1', false, function (Input)
+		
+		if SnapTracking.Target == nil then
+			return;
+		end;
 
 		-- Initialize snapping state
 		SnappingStage = 'Direction';


### PR DESCRIPTION
Fixed resize-snap bug if support is dragged onto a part that is not in the selection.

It's an edge case where the support sometimes snaps to parts outside the selection.  I'm using [a version of Rōblox from 2021](https://github.com/Windows81/Roblox-Freedom-Distribution/releases), so that might not apply in a proper production environment.