### PR TITLE
Fixing edge-case bug for history

### DIFF
--- a/Core/History.lua
+++ b/Core/History.lua
@@ -22,8 +22,7 @@ History = {
 
 function WaitForDebounce()
 	while History.Debounce do
-		-- task.wait();
-		wait();
+		task.wait();
 	end;
 end;
 

--- a/Core/History.lua
+++ b/Core/History.lua
@@ -13,9 +13,19 @@ History = {
 	Index = 0,
 
 	-- History change event
-	Changed = Signal.new()
+	Changed = Signal.new(),
+	
+	-- To prevent edge cases where multiple actions take place at the same time 
+	Debounce = false
 
 };
+
+function WaitForDebounce()
+	while History.Debounce do
+		-- task.wait();
+		wait();
+	end;
+end;
 
 function History.Undo()
 	-- Unapplies the previous record in stack
@@ -24,6 +34,10 @@ function History.Undo()
 	if History.Index - 1 < 0 then
 		return;
 	end;
+
+	-- Prevent edit conflicts
+	WaitForDebounce();
+	History.Debounce = true;
 
 	-- Get the history record, unapply it
 	local Record = History.Stack[History.Index];
@@ -35,6 +49,9 @@ function History.Undo()
 	-- Fire the Changed event
 	History.Changed:Fire();
 
+	-- Release debounce lock
+	History.Debounce = false;
+
 end;
 
 function History.Redo()
@@ -44,6 +61,10 @@ function History.Redo()
 	if History.Index + 1 > #History.Stack then
 		return;
 	end;
+	
+	-- Prevent edit conflicts
+	WaitForDebounce();
+	History.Debounce = true;
 
 	-- Update the index
 	History.Index = History.Index + 1;
@@ -55,10 +76,17 @@ function History.Redo()
 	-- Fire the Changed event
 	History.Changed:Fire();
 
+	-- Release debounce lock
+	History.Debounce = false;
+	
 end;
 
 function History.Add(Record)
 	-- Adds new history record to stack
+
+	-- Prevent edit conflicts
+	WaitForDebounce();
+	History.Debounce = true;
 
 	-- Update the index
 	History.Index = History.Index + 1;
@@ -73,6 +101,9 @@ function History.Add(Record)
 
 	-- Fire the Changed event
 	History.Changed:Fire();
+
+	-- Release debounce lock
+	History.Debounce = false;
 
 end;
 


### PR DESCRIPTION
I occasionally get this error.  It happens sporadically whenever I undo and I'm working on a fix for it.  I think that it's a race-condition issue.

When it happens, `History.Index` is greater than `#History.Stack`.  I believe that all the entries in `History.Stack` were valid when they were added in `History.Add`.
```
Players.VisualPlugin.Backpack.Building Tools.Core.History:31: attempt to index nil with 'Unapply'
    Stack Begin
    Script 'Players.VisualPlugin.Backpack.Building Tools.Core.History', Line 31 - function Undo
    Script 'Players.VisualPlugin.Backpack.Building Tools.Core', Line 144
    Script 'Players.VisualPlugin.Backpack.Building Tools.Libraries.SupportLibrary', Line 522
    Stack End
```