### PR TITLE
fix: Use Decal for model thumbnail

### DIFF
--- a/ThumbnailCamera.model.json
+++ b/ThumbnailCamera.model.json
@@ -1,0 +1,38 @@
+{
+	"ClassName": "Camera",
+	"Properties": {
+		"CameraType": "Custom",
+		"CFrame": [-9.0008564, 15.5936575, 0.905942082, -1, 0, 0, 0, 0.156434327, 0.987688363, 0, 0.987688363, -0.156434327],
+		"Focus": [-8.92682648, 13.9856577, 1.1120261, 1, 0, 0, 0, 1, 0, 0, 0, 1]
+	},
+	"Children": [
+		{
+			"Name": "ThumbnailPart",
+			"ClassName": "Part",
+			"Properties": {
+				"Size": [0.7, 0.7, 0.2],
+				"CFrame": [-9, 15, 1, 1, 0, 0, 0, 0.1564316, -0.987691224, 0, 0.987691224, 0.1564316],
+				"Transparency": 1,
+				"Anchored": true,
+				"CanCollide": false
+			},
+			"Children": [
+				{
+					"Name": "Decal",
+					"ClassName": "Decal",
+					"Properties": {
+						"Texture": "rbxassetid://455573525",
+						"Face": "Front"
+					}
+				},
+				{
+					"Name": "ThumbnailClearer",
+					"ClassName": "Script",
+					"Properties": {
+						"Source": "script.Parent:Destroy()"
+					}
+				}
+			]
+		}
+	]
+}

--- a/default.project.json
+++ b/default.project.json
@@ -82,6 +82,9 @@
         "Interfaces": {
           "$className": "Folder",
           "$ignoreUnknownInstances": true
+        },
+        "ThumbnailCamera": {
+          "$path": "ThumbnailCamera.model.json"
         }
       }
     }


### PR DESCRIPTION
This also replaces the ThumbnailCamera included in `Build/*.rbxmx` with one defined with Rojo in `ThumbnailCamera.model.json`.