### PR TITLE
fix: Size binding not being set in Dropdown Menus

### DIFF
--- a/UI/Dropdown.lua
+++ b/UI/Dropdown.lua
@@ -72,6 +72,11 @@ function Dropdown:render()
                 AreOptionsVisible = not self.state.AreOptionsVisible;
             })
         end;
+        [Roact.Ref] = function (rbx)
+			if rbx then
+				self.SetSize(rbx.AbsoluteSize)
+			end
+		end;
     }, {
         Corners = new('UICorner', {
             CornerRadius = UDim.new(0, 4);


### PR DESCRIPTION
Use a ref to explicitly trigger an update of the AbsoluteSize after mount w/ DropDown menu items.

Closes #187 